### PR TITLE
stop using Test::Base

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,10 +30,4 @@ WriteMakefile(
             }
         },
     ) : ()),
-    ($EUMM_VERSION >= 6.5501 ? (
-        BUILD_REQUIRES => {
-            'Test::Base' => 0,   # gotta test the minimum
-        },
-    ) : ()),
-
 );


### PR DESCRIPTION
This removes the use of Test::Base.  I don't think it provides any real advantages, especially given its prerequisite chain.
