### PR TITLE
Include stack traces for objects

### DIFF
--- a/lib/Carp/Always.pm
+++ b/lib/Carp/Always.pm
@@ -8,6 +8,8 @@ use warnings;
 our $VERSION = '0.12';
 
 use Carp qw(verbose); # makes carp() cluck and croak() confess
+use Moo::Role ();
+use overload ();
 
 sub _warn {
   if ($_[-1] =~ /\n$/s) {
@@ -17,9 +19,17 @@ sub _warn {
   }
   warn &Carp::longmess;
 }
+$Carp::Internal{+__PACKAGE__}++;
 
 sub _die {
-  die @_ if ref($_[0]);
+  if (ref $_[0]) {
+    my $ex = $_[0];
+    my $stringify = overload::Method($ex, '""');
+    Moo::Role->apply_roles_to_object($ex, 'Carp::Always::AttachTrace');
+    $ex->_stringify($stringify);
+    $ex->_trace(Carp::longmess);
+    die $ex;
+  }
   if ($_[-1] =~ /\n$/s) {
     my $arg = pop @_;
     $arg =~ s/(.*)( at .*? line .*?\n$)/$1/s;
@@ -39,6 +49,19 @@ BEGIN {
 END {
   @SIG{qw(__DIE__ __WARN__)} = @OLD_SIG{qw(__DIE__ __WARN__)};
 }
+
+{
+  package Carp::Always::AttachTrace;
+  use Moo::Role;
+  has _stringify => (is => 'rw');
+  has _trace => (is => 'rw');
+  use overload '""' => sub {
+    my $self = shift;
+    my $stringify = $self->_stringify || \&overload::StrVal;
+    return ($self->$stringify . $self->_trace);
+  };
+}
+
 
 1;
 __END__


### PR DESCRIPTION
This makes Carp::Always also include stack traces when exception objects are used.

I'm not proposing this code go in unmodified.  For one, it doesn't work with non-object references.  I also don't think it's reasonable to make Moo a prerequisite for this module.

But I'd like to know if you are interested in including this functionality in some form before I continue working on it.
